### PR TITLE
Corrected small typing mistake

### DIFF
--- a/How to write a smart contract and mint Elon Musk NFT on OpenSea/3. Blockchain Environment/1. Launching Your NFT on Testnet.md
+++ b/How to write a smart contract and mint Elon Musk NFT on OpenSea/3. Blockchain Environment/1. Launching Your NFT on Testnet.md
@@ -213,7 +213,7 @@ Now you are ready to deploy your contract to Polygon Mumbai Network. Wohoo!! The
 Let's run the command in our terminal and run this project.
 
 ```
-npx hardhat run scripts/deploy.js --network polygon_mumbai
+npx hardhat run scripts/run.js --network polygon_mumbai
 ```
 
 Congratulations you have just deployed your smart contract to the Ethereum test network!


### PR DESCRIPTION
The issued code is available at line 216

```
npx hardhat run scripts/deploy.js --network polygon_mumbai
```

In this tutorial, we have renamed the deploy.js file to run.js. So below is the updated command.

```
npx hardhat run scripts/run.js --network polygon_mumbai
```