### PR TITLE
Added error message + fix for Rust installation

### DIFF
--- a/Build a Petition Filing dApp on the Fuel Network/2. Setting Up the Dev Environment/1. Setup Fuel Toolchain.md
+++ b/Build a Petition Filing dApp on the Fuel Network/2. Setting Up the Dev Environment/1. Setup Fuel Toolchain.md
@@ -98,6 +98,14 @@ Now, follow the following instructions to install the Rust and Fuel toolchain in
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 
+You might get the following error message after executing the command:
+```
+curl: (35) schannel: next InitializeSecurityContext failed: Unknown error (0x80092012)
+- The revocation function was unable to check revocation for the certificate.
+```
+It indicates that cURL was unable to check revocation for the certificate (which is the default behavior when it comes to communication with secure websites). The error usually occurs when you 
+are using an anti-virus or equivalent software that offers its own certificate. The quickest solution would be to disable your anti-virus temporarily, run the cURL command once more, and then enable it again.
+
 2. Run the following command to check the version of Rust installed in your system.
 
 ```


### PR DESCRIPTION
Added an error message that might pop up during the cURL comand execution to install Rust on Windows. Also added a quick and easy potential fix for it.