### PR TITLE
Specify Hardhat v2.17.1 in README for Issue #442 Compatibility

### DIFF
--- a/Writing your first Hello World contract in Solidity/1. Setting up the environment/2. Setting up.md
+++ b/Writing your first Hello World contract in Solidity/1. Setting up the environment/2. Setting up.md
@@ -76,20 +76,33 @@ Now open your terminal and run the following commands one by one. Just copy and 
 mkdir Hello-World
 cd Hello-World
 npm init --yes
-npm install --save-dev hardhat
 ```
 
-The above commands means that you created a `Hello-World` folder - an empty one. You entered that folder and initialised the project by making a `package.json` file. Then you installed hardhat in the same folder.
+The above commands means that you created a `Hello-World` folder - an empty one. You entered that folder and initialised the project by making a `package.json` file.
 
-If you have followed the instructions properly, and everything went according to the plan, you have HardHat installed. 🎉
+## Installing Hardhat
 
-Now write the following command on the terminal.
+In this tutorial, we will use Hardhat version 2.17.1 to ensure compatibility with the examples and features discussed. The default command npm install --save-dev hardhat installs the latest version of Hardhat, which might introduce changes or updates not covered in this tutorial.
+
+To avoid any potential compatibility issues and to align with the specific requirements of this tutorial, we will install Hardhat version 2.17.1. This version is known to work seamlessly with the tutorial's content, ensuring a smooth learning experience.
+
+To install Hardhat version 2.17.1, execute the following command in your terminal:
+
+```
+npm install --save-dev hardhat@2.17.1
+```
+
+This command specifies the @2.17.1 version tag, ensuring that you install the exact version needed for this tutorial.
+
+After completing the installation, you're ready to proceed with the rest of the tutorial. Congratulations, you have successfully installed Hardhat! 🎉
+
+After installation, initiate Hardhat to configure your development environment:
 
 ```
 npx hardhat
 ```
 
-You will see something like this.
+Follow the on-screen prompts to complete the setup. Here's an example of what you might see:
 
 ![HardHat-output.png](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/assets%20for%20Writing%20your%20first%20Hello%20World%20contract%20in%20Solidity/Setting%20up/HardHat-output.png?raw=true)
 


### PR DESCRIPTION
Updated README installation instructions to explicitly recommend Hardhat version 2.17.1, aligning with the requirements and ensuring full compatibility with the tutorial content addressed in Issue #442.