### PR TITLE
Update 1. Write Your Token Smart Contract in Move.md

### DIFF
--- a/Create a Fungible Token with Sui Move | Metaschool/3. Write Your Token Smart Contract in Move/1. Write Your Token Smart Contract in Move.md
+++ b/Create a Fungible Token with Sui Move | Metaschool/3. Write Your Token Smart Contract in Move/1. Write Your Token Smart Contract in Move.md
@@ -24,7 +24,7 @@ module metaschool::pepe {
 - Import modules (`std::option`, `sui::coin`, `sui::transfer`, and `sui::tx_context`) that contain pre-built functions and types to be used in the code.
 
 ```
-    struct PEPE has drop {}
+    public struct PEPE has drop {}
 ```
 
 - Define a new struct called `PEPE` with `has drop` attribute.


### PR DESCRIPTION
If the module be created by sui cli 1.25.0-4b63a10401d2 version, the manifest of package` edition = "2024.beta"` by default.

In Move 2024 edition, internal struct declarations are not yet supported. So, the struct declarations must add `public` to avoid build error

You can find Move 2024 migration reference in Sui Docs