### PR TITLE
Correction of wrong code given Build an Airbnb dApp on Fuel Network course for property_state

### DIFF
--- a/Build Airbnb on Fuel Network/3. Start Writing the Sway DApp/2. Create the Property Library.md
+++ b/Build Airbnb on Fuel Network/3. Start Writing the Sway DApp/2. Create the Property Library.md
@@ -109,21 +109,21 @@ Create one more file called `property_state.sw` and paste the following code:
 
 ```
 library;
+use core::ops::Eq;
 
-/// Used to track the Listings that a user has created.
-pub struct Property {
-    /// The unique identifier for the Listing.
-    id: u64,
+/// Represents the current state of the Property.
+pub enum PropertyState {
+    Listed: (),
+    Unlisted: (),
 }
 
-impl Property {
-    /// Creates a new Listing.
-    ///
-    /// # Arguments
-    ///
-    /// * `id`: [u64] - The unique identifier for the Listing.
-    pub fn new(id: u64) -> Self {
-        Self { id }
+impl Eq for PropertyState {
+    fn eq(self, other: PropertyState) -> bool {
+        match (self, other) {
+            (PropertyState::Listed, PropertyState::Listed) => true,
+            (PropertyState::Unlisted, PropertyState::Unlisted) => true,
+            _ => false,
+        }
     }
 }
 ```


### PR DESCRIPTION
The same code has been repeated here where the code of property.sw has been given again for property_state.sw.

The error is in the **Create the Property Library** section under **Start Writing the Sway DApp** module.

![image](https://github.com/0xmetaschool/Learning-Projects/assets/48171972/37340111-2f8c-4a32-93db-02e3040f99ab)

I've corrected the code by adding the **Listed and Unlisted** enum states as being used in the rest of the application.