### PR TITLE
Update 1. Deploy Your First Fungible Token on Sui.md

### DIFF
--- a/Create a Fungible Token with Sui Move | Metaschool/4. Deploy Your First Fungible Token on Sui/1. Deploy Your First Fungible Token on Sui.md
+++ b/Create a Fungible Token with Sui Move | Metaschool/4. Deploy Your First Fungible Token on Sui/1. Deploy Your First Fungible Token on Sui.md
@@ -14,7 +14,7 @@ module metaschool::pepe {
     use sui::tx_context::{Self, TxContext};
 
     // Name matches the module name, but in UPPERCASE
-    struct PEPE has drop {}
+  public struct PEPE has drop {}
 
     // Module initializer is called once on module publish.
     // A treasury cap is sent to the publisher, who then controls minting and burning.


### PR DESCRIPTION
Visibility annotations are required on struct declarations from the Move 2024 edition onwards. You must specify whether the struct is public or internal.