### PR TITLE
Update 2 mumbai is deprecated

### DIFF
--- a/Build Hogwarts Sorting Cap dApp on the Polygon Mumbai/1. Let’s Get Started/2. Set Up Your Project.md
+++ b/Build Hogwarts Sorting Cap dApp on the Polygon Mumbai/1. Let’s Get Started/2. Set Up Your Project.md
@@ -30,7 +30,7 @@ You will be successfully connected to Mumbai network. See in the following gif h
 Now its time to get some money!
 
 - Copy your account address from MetaMask.
-- Head over to [https://mumbaifaucet.com/](https://mumbaifaucet.com/).
+- Head over to [https://mumbaifaucet.com/](https://faucet.polygon.technology/).
 - Paste your wallet address.
 - Click on “Send me MATIC”.
 - You will receive 0.2 MATIC.


### PR DESCRIPTION
No Goerli = broken Mumbai. The community consensus across the Polygon ecosystem has deprecated Mumbai in tandem with Goerli. 

When Goerli went dark, so did Mumbai.