### PR TITLE
docs: Add troubleshooting guide for npm start error

### DIFF
--- a/Start Building on Aptos/2. Getting Started with Development on Aptos/3. Interacting with your Calculator Project.md
+++ b/Start Building on Aptos/2. Getting Started with Development on Aptos/3. Interacting with your Calculator Project.md
@@ -91,6 +91,40 @@ Well, this is how the dApp will look like in your browser, try clicking the turn
 
 ![FirstInteraction.gif](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/aptos-c2-building-on-aptos-assets/Interacting%20with%20your%20Calculator%20Project/FirstInteraction.gif?raw=true)
 
+## Solving the npm start Error: error:0308010C:digital envelope routines::unsupported
+If you encounter the following error after running npm start:
+
+```
+Error: error:0308010C:digital envelope routines::unsupported
+```
+This error often occurs due to an incompatibility between your Node.js version and the project's dependencies. To resolve it, follow these steps:
+
+1. Update project dependencies:
+Run the following command to update the project's dependencies, which may resolve any compatibility issues:
+
+    ```
+    npm update
+    ```
+2. Try starting the project again:
+After updating, try running the project again:
+
+    ```
+    npm start
+    ```
+3. Fix vulnerabilities (if the error persists):
+If the error persists, there might be vulnerabilities or issues that need to be addressed. Run the following command to audit and fix these issues:
+
+    ```
+    npm audit fix --force
+    ```
+4. Start the project:
+Finally, try starting the project again:
+
+    ```
+    npm start
+    ```
+Following these steps should resolve this npm start error and likely anyother error that is due to the incompatibility between your NodeJS version and the project's dependencies.
+
 ## Pushing it to Git
 
 Make sure you are in `Building-on-Aptos-boilerplate` folder. If you are in `interface` folder just run `cd ../` to return to the previous directory. Push your code to your GitHub repository using the following commands. 


### PR DESCRIPTION
Added a section to the README that provides a step-by-step guide for resolving the  `Error: error:0308010C:digital envelope routines::unsupported` issue that may occur  when running `npm start`. This error is typically due to an incompatibility between  Node.js versions and the project's dependencies.

The guide includes instructions to:
1. Update project dependencies.
2. Retry starting the project.
3. Audit and fix potential vulnerabilities.
4. Ensure the project runs successfully after fixes.

This addition aims to assist users who encounter this common issue and provide  clear steps to resolve it.