### PR TITLE
docs: Fix typo and improve formatting in README

### DIFF
--- a/Start Building on Aptos/3. Structs and Resources in Move/1. Mastering the Art of Structuring Your dApp.md
+++ b/Start Building on Aptos/3. Structs and Resources in Move/1. Mastering the Art of Structuring Your dApp.md
@@ -108,7 +108,8 @@ module metaschool::calculator {
 
 Let’s focus on the struct part and understand what we did in the code.
 
-- We created a `Calculator` struct inside the c`alculator` module with one field, `result`. Here, we will use a `calculator` struct to store the result of the calculator's operation. For example, if we want to store the addition result, we will store it in the `Calculator`'s `result` field.  **Note:** It is important to specify data type for struct field. Don’t worry! We will explore data types in detail in upcoming lessons.
+- We created a `Calculator` struct inside the `calculator` module with one field, `result`. Here, we will use a `calculator` struct to store the result of the calculator's operation. For example, if we want to store the addition result, we will store it in the `Calculator`'s `result` field.
+**Note:** It is important to specify data type for struct field. Don’t worry! We will explore data types in detail in upcoming lessons.
 - Next, inside the function (`create_calculator`), we are initializing the `calculator` variable using the `Calculator` struct.
 
 ## That’s a wrap


### PR DESCRIPTION
Fixed a typo in the README where the "c" in the word "calculator" was incorrectly placed outside the back-ticks, appearing as c`alculator`. This typo has been corrected for proper formatting.

Additionally, improved the visibility of a Note by moving it to a new line, making it easier for users to notice and follow.