### PR TITLE
docs: Correct public to private on line 5 and spacing in Move code

### DIFF
--- a/Start Building on Aptos/4. Variables, Constants, and Functions in Move/4. Understanding Visibility Specifiers for Function.md
+++ b/Start Building on Aptos/4. Variables, Constants, and Functions in Move/4. Understanding Visibility Specifiers for Function.md
@@ -2,7 +2,7 @@
 
 As developers, we're the architects shaping the operations within our blockchain applications. However, just like a master architect designing a complex structure, we must carefully decide who can access specific functions.
 
-All of the functions we had created in the previous lesson like `add()` , `subtract()`, `multiply()`, `divide()`, `power()`, and `get_result()` are currently private by default. That’s just how it works in Aptos Move, unless we explicitly specify the visibility of a function they will stay public , meaning they can’t be accessed outside of our module. so we need to make our front-end 📱to be able to summon these functions.
+All of the functions we had created in the previous lesson like `add()` , `subtract()`, `multiply()`, `divide()`, `power()`, and `get_result()` are currently private by default. That’s just how it works in Aptos Move, unless we explicitly specify the visibility of a function they will stay private , meaning they can’t be accessed outside of our module. so we need to make our front-end 📱to be able to summon these functions.
 
 ![calcu-ezgif com-resize](https://github.com/0xmetaschool/Learning-Projects/assets/130544719/db524e1a-a6c6-4c97-8012-07d76340c081)
 
@@ -21,7 +21,7 @@ module maths::multiplication {
 }
 
 module maths::call {
-		use maths::multiplication;
+    use maths::multiplication;
 		
     fun call_maths_package(): u64 {
         maths::multiplication::return(); // ERROR
@@ -41,7 +41,7 @@ You can use the `public` keyword to make a function public. Public functions are
 
 ```
 module maths::multiplication {
-		public fun multiply(value: u64): u64 {
+    public fun multiply(value: u64): u64 {
         value * 2;
     }
 }
@@ -59,26 +59,26 @@ Let’s look at a complete example to understand the above points.
 
 ```
 module maths::multiplication {
-		public fun multiply(value: u64): u64 {
+    public fun multiply(value: u64): u64 {
         value * 2;
     }
-    
+
     fun return(): u64 {
         42;
     }
 }
 
 module maths::addition {
-		public fun add(value: u64): u64 {
-				let res : u64 = maths::multiplication::multiply(value);
+    public fun add(value: u64): u64 {
+        let res : u64 = maths::multiplication::multiply(value);
         res + value + 2;
     }
 }
 
 module maths::call {
-		use maths::multiplication;
-		use maths::addition;
-		
+    use maths::multiplication;
+    use maths::addition;
+
     fun call_maths_package(value: u64): u64 {
         maths::multiplication::multiply(value); // VALID
         maths::addition::add(value); // VALID
@@ -102,37 +102,37 @@ Let’s look at the detailed example.
 
 ```
 module maths::multiplication {
-		friend maths::addition; // friend declaration
-		
-		public(friend) fun multiply(value: u64): u64 {
+    friend maths::addition; // friend declaration
+
+    public(friend) fun multiply(value: u64): u64 {
         value * 2;
     }
-    
+
     fun call_addition(value: u64): u64 {
-	    maths::addition::add(value); // VALID
+        maths::addition::add(value); // VALID
     }
 }
 
 module maths::addition {
-		public fun add(value: u64): u64 {
-				let res : u64 = maths::multiplication::multiply(value); // VALID
+    public fun add(value: u64): u64 {
+        let res : u64 = maths::multiplication::multiply(value); // VALID
         res + value + 2;
     }
 }
 
 module maths::subtraction {
-		public fun sub(value: u64): u64 {
-				/* The following line will throw an error as the subtraction module is not
-				   a friend of the multiplication module. */
-				let res : u64 = maths::multiplication::multiply(value); // ERROR
+    public fun sub(value: u64): u64 {
+        /* The following line will throw an error as the subtraction module is not
+        a friend of the multiplication module. */
+        let res : u64 = maths::multiplication::multiply(value); // ERROR
         value - 2;
     }
 }
 
 module maths::call {
-		use maths::multiplication;
-		use maths::addition;
-		
+    use maths::multiplication;
+    use maths::addition;
+
     fun calls_maths_package(value: u64): u64 {
         maths::multiplication::multiply(value); // ERROR
         maths::addition::add(value); // VALID


### PR DESCRIPTION
- Corrected a typo where `public` was used instead of `private`.  (line 5) Since functions in Move are private by default, unless they are explicitly specify to be public.
- Adjusted the spacing and formatting of function definitions to ensure consistency and improve readability.