### PR TITLE
docs: fix typo

### DIFF
--- a/Start Building on Aptos/5. Operators and Control Flow in Move/1. Introduction to Operators.md
+++ b/Start Building on Aptos/5. Operators and Control Flow in Move/1. Introduction to Operators.md
@@ -47,7 +47,7 @@ Much like every other programming, Solidity has a special set of symbols called 
     ```
     
 
-Most of these operators work similarly to how they do in other programming languages, making them easy to understand and use if you're already familiar with languages like JavaScript, C++, or Python. We're mostly just listing these operators out to show their specific applications in Solidity.
+Most of these operators work similarly to how they do in other programming languages, making them easy to understand and use if you're already familiar with languages like JavaScript, C++, or Python. We're mostly just listing these operators out to show their specific applications in Move.
 
 ## Code Makeover: Adding Operators
 


### PR DESCRIPTION
correct by changing Solidity to Move, as we are focusing on Move and not Solidity, hence the use case in this tutorial is for move and not for Solidity.