### PR TITLE
fix: Correct logic in power function for zero exponent case

### DIFF
--- a/Start Building on Aptos/5. Operators and Control Flow in Move/3. Transform Your dApp Using Loop Scoop.md
+++ b/Start Building on Aptos/5. Operators and Control Flow in Move/3. Transform Your dApp Using Loop Scoop.md
@@ -142,7 +142,7 @@ Ready? Let’s get powered up!
 public entry fun power(account: &signer, num1: u64, num2: u64) acquires Calculator {
   let calculator = borrow_global_mut<Calculator>(signer::address_of(account));
   if (num2 == 0) {
-      abort error::invalid_argument(0)
+      calculator.result = 1;
   } else {
       let i = 1;
       calculator.result = num1;


### PR DESCRIPTION
- Corrected the logic in the power function where it incorrectly handled the case  when `num2 == 0`. The function was originally set to abort when the exponent was zero.
- Updated the logic so that when `num2 == 0`, the function correctly returns `1`,  since any number raised to the power of zero should always equal one.