### PR TITLE
Update 5. Setting up the project structure.md

### DIFF
--- a/Core C3 Launching a 10K NFT collection on Core/2. Building the 10k NFT Collection/5. Setting up the project structure.md
+++ b/Core C3 Launching a 10K NFT collection on Core/2. Building the 10k NFT Collection/5. Setting up the project structure.md
@@ -64,7 +64,7 @@ Let’s add it to MetaMask so you can access it:
     - **Network Name:** Core Testnet
     - **New RPC URL:** [https://rpc.test.btcs.network](https://rpc.test.btcs.network/)
     - **ChainID:** 1115
-    - **Symbol:** CORE
+    - **Symbol:** tCORE
 6. **Save:** Hit "Save," and you're in! It will ask you to switch to the network, well switch!
 
 ![image (11)](https://github.com/user-attachments/assets/920027b5-8ca5-4efe-98fd-be6766afe6a1)


### PR DESCRIPTION
Metamask suggested the symbol name CORE was not identified for the testnet but that a symbol name such as tCORE was suggested instead of CORE.