### PR TITLE
docs: Fix typo

### DIFF
--- a/Aptos C3 Create a Fungible Token on Aptos/3. Build Your Token/7. Finalize the essentials.md
+++ b/Aptos C3 Create a Fungible Token on Aptos/3. Build Your Token/7. Finalize the essentials.md
@@ -23,7 +23,7 @@ The `authorized_borrow_refs` function will take two parameters:
 - `owner`: The signer (Owner/Administrator) who is requesting access to the asset references.
 - `asset`: The metadata object associated with the token, containing essential information about the token.
 
-In-order to perform the verification, we will use the `is_owner` function to check if the `owner` we have provided via the parameters is actually the owner or not using the `assert` macro. If the assertion fails we will throw and `permission_denied(ENOT_OWNER)` error.
+In-order to perform the verification, we will use the `is_owner` function to check if the `owner` we have provided via the parameters is actually the owner or not using the `assert` macro. If the assertion fails we will throw a `permission_denied(ENOT_OWNER)` error.
 
 Finally If ownership checks out, the function then grabs a managed reference of `ManagedFungibleAsset` to the global resource using `object_address(&asset)`. We have used the same function in our previous function definitions as well.
 


### PR DESCRIPTION
correct a typo where `and` was used instead of  `a`.