### PR TITLE
docs: Fix typo

### DIFF
--- a/C4 Rock Paper Scissor on Aptos/1. Getting started/1. What Are We Building Today.md
+++ b/C4 Rock Paper Scissor on Aptos/1. Getting started/1. What Are We Building Today.md
@@ -42,7 +42,7 @@ We will:
 
 ## Who exactly should take this course?
 
-This course is for  Web3 developers who wish to dive deeper into the Aptos world and have completed our three two courses on Aptos. You should have basic programming knowledge as it will help you have a quick start to this course but if not, we are here for you!
+This course is for  Web3 developers who wish to dive deeper into the Aptos world and have completed our first three (beginner) courses on Aptos. You should have basic programming knowledge as it will help you have a quick start to this course but if not, we are here for you!
 
 ## What will you be getting out of this course?
 


### PR DESCRIPTION
correction made on line 45, where `three two` was changed to `first three (beginner)`