### PR TITLE
fix: Correct broken image link formatting in documentation

### DIFF
--- a/C4 Rock Paper Scissor on Aptos/2. Set Up Dev Environment/4. Set Up the Rock Paper Scissor Project on Move.md
+++ b/C4 Rock Paper Scissor on Aptos/2. Set Up Dev Environment/4. Set Up the Rock Paper Scissor Project on Move.md
@@ -39,7 +39,7 @@ Once you have installed the Git CLI, let me tell you how you can configure your 
         4. Then, press Enter. It will open a window in your browser.
         5. Paste the code you copied and authorize your git. You might need to enter your GitHub password if you have yet to log in.
     
-    ![Screen Recording 2024-07-15 at 11.44.49 AM.gif](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/C4%20Rock%20Paper%20Scissor%20on%20Aptos%20Images/Lesson%204%20Set%20Up%20the%20Rock%20Paper%20Scissor%20Project%20on%20Move/Screen_Recording_2024-07-15_at_11.44.49_AM.gif?raw=true)
+![Screen Recording 2024-07-15 at 11.44.49 AM.gif](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/C4%20Rock%20Paper%20Scissor%20on%20Aptos%20Images/Lesson%204%20Set%20Up%20the%20Rock%20Paper%20Scissor%20Project%20on%20Move/Screen_Recording_2024-07-15_at_11.44.49_AM.gif?raw=true)
     
 
 Awesome, you are all set!! Good job!


### PR DESCRIPTION
- Fixed a broken link to an image in the documentation. The initial spacing before the link  caused it to be rendered as a code snippet rather than a functional link.
  
- Removed the excess space at the beginning of the link to ensure it is properly  formatted and displayed as an active hyperlink.