### PR TITLE
docs: Specify language in code snippets for proper syntax highlighting

### DIFF
--- a/C4 Rock Paper Scissor on Aptos/3. Building rock paper scissor game/8. Game State Management.md
+++ b/C4 Rock Paper Scissor on Aptos/3. Building rock paper scissor game/8. Game State Management.md
@@ -19,7 +19,7 @@ In a centralized system, picking a random winner from a list of participants is 
 
 Before the introduction of Aptos Roll, developers often resorted to insecure methods for generating random numbers. For example:
 
-```
+```move
 module module_owner::lottery {
     struct LotteryState {
         players: vector<address>,
@@ -60,7 +60,7 @@ With Aptos Roll, generating secure random numbers is straightforward. Here's how
 
 Annotate entry functions that depend on randomness with `#[randomness]` to make them compliant:
 
-```
+```move
 #[randomness]
 entry fun decide_winner() {
     let lottery_state = load_lottery_state_mut();
@@ -76,7 +76,7 @@ This attribute ensures that the function is recognized by the Aptos VM and can s
 
 Use the randomness functions provided by the API. Here are some examples:
 
-```
+```move
 module aptos_framework::randomness {
     // Generates a number uniformly at random.
     fun u8_integer(): u8 {}
@@ -117,7 +117,7 @@ Let's find out how to use the Aptos randomness API in your code.
 
 A complete list of API functions for generating random numbers of various types is available. Here’s an overview:
 
-```
+```move
 module aptos_framework::randomness {
     fun u8_integer(): u8 {}
     fun u16_integer(): u16 {}
@@ -136,7 +136,7 @@ We will use this feature to implement the logic of our game. So let’s begin~
 
 First, let’s quickly swap out our boilerplate with the corresponding front end for these functionalities. 
 
-```
+```bash
 git checkout origin/boilerplate_03
 ```
 
@@ -148,13 +148,13 @@ We will dive into the features and functionalities that we have added.
 
 First, we will add the `randomness` module to our code.
 
-```
+```move
 use aptos_framework::randomness;
 ```
 
 Next, we will define the `duel` function.
 
-```
+```move
 #[randomness]
 entry fun duel(account: &signer, user_selection: String) acquires DuelResult {
 ```
@@ -166,19 +166,19 @@ entry fun duel(account: &signer, user_selection: String) acquires DuelResult {
     - `user_selection: String`: A string representing the user's selection (Rock, Paper, or Scissors).
 - `acquires DuelResult` specifies that this function will access and modify `DuelResult` resources in the global storage.
 
-```
+```move
 let random_number = randomness::u64_range(0, 3); // 3 is exclusive
 ```
 
 - This line generates a random number between 0 and 2 (inclusive) using the `randomness::u64_range` function. The `3` is exclusive, meaning the possible values are 0, 1, or 2.
 
-```
+```move
 let result = borrow_global_mut<DuelResult>(signer::address_of(account));
 ```
 
 - This line borrows the `DuelResult` resource associated with the account's address from the global storage, allowing it to be modified.
 
-```
+```move
 if(random_number==0)
 {
     result.computer_selection = utf8(b"Rock");
@@ -201,13 +201,13 @@ else
     - If `random_number` is 1, the computer's selection is "Paper".
     - If `random_number` is 2, the computer's selection is "Scissors".
 
-```
+```move
 let computer_selection = &result.computer_selection;
 ```
 
 - This line creates a reference to the `computer_selection` field of the `DuelResult` resource.
 
-```
+```move
 if (user_selection == *computer_selection) {
     result.duel_result = utf8(b"Draw"); // Draw
 } else if ((user_selection == utf8(b"Rock") && *computer_selection == utf8(b"Scissors")) ||
@@ -230,7 +230,7 @@ if (user_selection == *computer_selection) {
 
 Lastly, we have a `get_result` function that retrieves the computer's selection and the duel result for a given user's account. It takes the signer's account as a parameter, borrows the `DuelResult` resource associated with the account's address, and returns a tuple containing the computer's selection and the duel result.
 
-```
+```move
     public fun get_result(account: &signer): (String, String) acquires DuelResult {
         let result = borrow_global<DuelResult>(signer::address_of(account));
         (result.computer_selection, result.duel_result)
@@ -243,7 +243,7 @@ Whew! We are doneeeeeee with the code! Let’s deploy and see how it works.
 
 Let’s deploy the contract using the CLI. Open a terminal in the `rock-paper-scissors-aptos-dapp` folder and run the following command:
 
-```
+```bash
 aptos move compile
 ```
 
@@ -255,7 +255,7 @@ The command will essentially compile our code and if the compilation is successf
 
 The following command will publish our code to the Aptos testnet. While running the command, it will prompt you regarding the transaction fee payment, just add a ‘yes’ there.
 
-```
+```bash
 aptos move publish
 ```
 


### PR DESCRIPTION
- Updated various code snippets in the documentation to include the appropriate language specifier (e.g., `bash`, `move`). Previously, the code snippets were  enclosed between triple back-ticks without specifying the language, leading to a lack of syntax highlighting.

- Adding the correct language specifier improves readability and helps users better understand the code by providing syntax highlighting.