### PR TITLE
fix: correct broken link to MetaSchool GitHub repository

### DIFF
--- a/Documents Management DApp on Aptos/1. Introduction and DApp Overview/1. What Are We Building Today.md
+++ b/Documents Management DApp on Aptos/1. Introduction and DApp Overview/1. What Are We Building Today.md
@@ -62,7 +62,7 @@ Now before we move forward, let’s set some house rules first.
 
 1. Kindly do your quick assignments properly.
 2. Join [our discord server](https://discord.gg/Jf4ArqVb) and ask all relevant questions there.
-3. We are a free open-source platform and if you follow us on [Github](github.com/0xmetaschool), it would be a great support. 🫣
+3. We are a free open-source platform and if you follow us on [Github](https://github.com/0xmetaschool), it would be a great support. 🫣
 4. Stay happy and positive!
 
 Alright guys, no need to wait any longer. Let’s get started!


### PR DESCRIPTION
The link to the MetaSchool GitHub repository was incorrectly formatted, missing the `"https://"` prefix. This caused the link to redirect to an incorrect URL relative to the current site. Updated the link to include the full `"https://github.com/0xmetaschool"` URL, ensuring it directs users to the correct repository page.