### PR TITLE
fix: correct branch name from 'boilerplate01' to 'boilerplate_01'

### DIFF
--- a/Documents Management DApp on Aptos/2. Project Structure and Setup/1. Setting Up the Dev Wizard.md
+++ b/Documents Management DApp on Aptos/2. Project Structure and Setup/1. Setting Up the Dev Wizard.md
@@ -18,13 +18,13 @@ There are a few tools that you need to install to proceed with the course. Make 
 
 ## Setting up your project
 
-We will first make sure that we are at the right branch. Run the following command to be at the `boilerplate01` branch. 
+We will first make sure that we are at the right branch. Run the following command to be at the `boilerplate_01` branch. 
 
 ```
-git checkout boilerplate01
+git checkout boilerplate_01
 ```
 
-At `boilerplate01`, we have made a basic Aptos Move project for you with the basic move file. You’ll have to implement the code in those files.
+At `boilerplate_01`, we have made a basic Aptos Move project for you with the basic move file. You’ll have to implement the code in those files.
 
 ![aptos-structure.png](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/Documents%20Management%20DApp%20on%20Aptos-C5/2.%20Project%20Structure%20and%20Setup/1.%20Setting%20Up%20the%20Dev%20Wizard/aptos-structure.png?raw=true)
 


### PR DESCRIPTION
Corrected a spelling error in the branch name mentioned in the documentation. The branch was incorrectly referred to as 'boilerplate01', whereas the correct branch name in the repository is 'boilerplate_01'.