### PR TITLE
text and link update: Updated the text on ArgentX (both about and link on chrome store)

### DIFF
--- a/Code an ERC-20 token in Cairo on Starknet Blockchain/2. Setting up the Development Environment/1. Set Up Starkli, Scarb, And ArgentX.md
+++ b/Code an ERC-20 token in Cairo on Starknet Blockchain/2. Setting up the Development Environment/1. Set Up Starkli, Scarb, And ArgentX.md
@@ -89,9 +89,9 @@ Now let’s move on to ArgentX setup…
 
 ## Setup ArgentX
 
-It is one of most popular wallet and only-freely available wallet on Starknet.
+It is one of the most popular wallet and freely available wallet on Starknet.
 
-You can add it easily using browser extension. For chrome, just go to [this](https://chrome.google.com/webstore/detail/argent-x/dlcobpjiigpikoobohmabehhmhfoodbb/related) link and then add to chrome.
+You can add it easily using browser extension. For chrome, just go to [this](https://chromewebstore.google.com/detail/argent-x-starknet-wallet/dlcobpjiigpikoobohmabehhmhfoodbb) link and then add to chrome.
 
 ![Frame 3560364 (13).jpg](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/assests_for_starknet/Set%20Up%20Starkli,%20Scarb,%20And%20ArgentX/Frame_3560364_(13).jpg?raw=true)
 


### PR DESCRIPTION
I updated the text of `ArgentX being the one and only popular wallet` to it being `one of the popular` as for now there is also another called `Bravos` which is also quite popular in the starknet ecosystem. 

Also, the link to the Chrome store doesn't take one directly to the ArgentX wallet, I was also able to fix that.

Thank you!