### PR TITLE
text update: updated link to starkscan.

### DIFF
--- a/Code an ERC-20 token in Cairo on Starknet Blockchain/4. Deploy Your First ERC20 Token on Starknet/1. Deploy Your First ERC20 Token on Starknet.md
+++ b/Code an ERC-20 token in Cairo on Starknet Blockchain/4. Deploy Your First ERC20 Token on Starknet/1. Deploy Your First ERC20 Token on Starknet.md
@@ -179,7 +179,7 @@ The output of the above command is shown below.
 
 ![Screen Shot 2023-12-29 at 3.51.01 PM.png](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/assests_for_starknet/Deploy%20Your%20First%20ERC20%20Token%20on%20Starknet%20%5Bupdated%5D/Screen_Shot_2023-12-29_at_3.51.01_PM.png?raw=true)
 
-Your contract is deployed!!! You can go to the [StarkScan](https://testnet.starkscan.co/) transaction hash link. Paste the address before your contract deployed and check out its overview. 
+Your contract is deployed!!! You can go to the [StarkScan](https://sepolia.starkscan.co/) transaction hash link. Paste the address before your contract deployed and check out its overview. 
 
 ![Frame 3560365 (6).jpg](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/assests_for_starknet/Deploy%20Your%20First%20ERC20%20Token%20on%20Starknet%20%5Bupdated%5D/Frame_3560365_(6).jpg?raw=true)
 


### PR DESCRIPTION
The link to starkscan `https://testnet.starkscan.co/` is no longer working, hence updated it to a corresponding working one, which is the `https://sepolia.starkscan.co/`.