### PR TITLE
Corrected the term 'public' to 'private' for accuracy

### DIFF
--- a/Start Building on Aptos/4. Variables, Constants, and Functions in Move/4. Understanding Visibility Specifiers for Function.md
+++ b/Start Building on Aptos/4. Variables, Constants, and Functions in Move/4. Understanding Visibility Specifiers for Function.md
@@ -2,7 +2,7 @@
 
 As developers, we're the architects shaping the operations within our blockchain applications. However, just like a master architect designing a complex structure, we must carefully decide who can access specific functions.
 
-All of the functions we had created in the previous lesson like `add()` , `subtract()`, `multiply()`, `divide()`, `power()`, and `get_result()` are currently private by default. That’s just how it works in Aptos Move, unless we explicitly specify the visibility of a function they will stay public , meaning they can’t be accessed outside of our module. so we need to make our front-end 📱to be able to summon these functions.
+All of the functions we had created in the previous lesson like `add()` , `subtract()`, `multiply()`, `divide()`, `power()`, and `get_result()` are currently private by default. That’s just how it works in Aptos Move, unless we explicitly specify the visibility of a function they will stay private , meaning they can’t be accessed outside of our module. so we need to make our front-end 📱to be able to summon these functions.
 
 ![calcu-ezgif com-resize](https://github.com/0xmetaschool/Learning-Projects/assets/130544719/db524e1a-a6c6-4c97-8012-07d76340c081)
 


### PR DESCRIPTION
This change ensures that the documentation accurately matches the intended message to be passed, avoiding potential confusion for developers and users referring to the file. No functional changes were made, only the update to the text.