### PR TITLE
fix: typos in documentation files

### DIFF
--- a/Build Airbnb on Fuel Network/4. Deploy the DApp/1. Set Up the Fuel Wallet.md
+++ b/Build Airbnb on Fuel Network/4. Deploy the DApp/1. Set Up the Fuel Wallet.md
@@ -55,7 +55,7 @@ Open a new terminal in your `airbnb-contract` directory and complete the followi
     ![wallet-4.png](https://github.com/0xmetaschool/Learning-Projects/blob/main/assests_for_all/assets_for_petition_fuel/Setup%20Fuel%20Wallet/wallet-4.png?raw=true)
     
 
-- And we are all set, let now move on to top it up with some faucet ETH because we will be needing this to pay for the gas.
+- And we are all set, let's now move on to top it up with some faucet ETH because we will be needing this to pay for the gas.
 
 **Note:** Your wallet might not show the same wallet address as shown on your terminal. So, remember to use the wallet address shown on the terminal to get some fake tokens.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you find an error, resolve it and submit a pull request. Let's build this! �
 
 ## 🤝 Sounds fun! How do I contribute
 
-Since our projects and their tutorials are available and opensourced for everyone, you can step us and report issues, resolve them and become a contributer too. [Follow this short guide](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository) by GitHub on how you can edit & contribute.
+Since our projects and their tutorials are available and open-sourced for everyone, you can step up and report issues, resolve them and become a contributor too. [Follow this short guide](https://docs.github.com/en/repositories/working-with-files/managing-files/editing-files#editing-files-in-another-users-repository) by GitHub on how you can edit & contribute.
 
 ## ✨ Contributors
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "let" to "let's".
Corrected "opensourced" to "open-sourced".
Corrected "contributer" to "contributor".
Corrected "step us" to "step up".

Please review the changes and let me know if any additional changes are needed.

