### PR TITLE
fix: typos in documentation files

### DIFF
--- a/Code an ERC-20 token in Cairo on Starknet Blockchain/4. Deploy Your First ERC20 Token on Starknet/1. Deploy Your First ERC20 Token on Starknet.md
+++ b/Code an ERC-20 token in Cairo on Starknet Blockchain/4. Deploy Your First ERC20 Token on Starknet/1. Deploy Your First ERC20 Token on Starknet.md
@@ -67,7 +67,7 @@ Now we need to export the private key of your account. Enter your password of th
     
     
 
-Now run thefollowing command:
+Now run the following command:
 
 ```
 starkli signer keystore from-key starkli-wallets/deployer/keystore.json

--- a/Launch your own epic NFT marketplace/1. Getting Started/1. Intro.md
+++ b/Launch your own epic NFT marketplace/1. Getting Started/1. Intro.md
@@ -23,7 +23,7 @@ This is a great head start for anyone looking to create NFT collection or a mark
 So what exactly are we going to cover today
 
 - We will start of with setting up our development environment and downloading all the dependencies. The tech stack we will be using today is - Hardhat, Alchemy, Pinata, React and Ethers.js
-- We will then use the openzepellin library’s ERC721 smart contract, and inherit it to create our own NFT smart contract called `Collection.sol`.
+- We will then use the OpenZeppelin library’s ERC721 smart contract, and inherit it to create our own NFT smart contract called `Collection.sol`.
 - After that we will need to deploy our smart contract using `ethers.js` and check our deployment on etherscan.
 - Once all the solidity part is done, we’ll make a very simple react frontend for our website.
 - This webpage will be able to list 5 NFTs, a user would be able to connect to their metamask and mint any 2 of these NFTs.


### PR DESCRIPTION
Corrected `Now run thefollowing command` to `Now run the following command`
Corrected `openzepellin` to `OpenZeppelin`