### PR TITLE
Fix typos in Documentation

### DIFF
--- a/Build a Petition Filing dApp on the Fuel Network/4. Writing Your Smart Contract/2. Let’s Add the States and Interfaces.md
+++ b/Build a Petition Filing dApp on the Fuel Network/4. Writing Your Smart Contract/2. Let’s Add the States and Interfaces.md
@@ -70,7 +70,7 @@ impl Eq for CampaignState {
     fn eq(self, other: CampaignState) -> bool {
         match (self, other) {
             (CampaignState::Cancelled, CampaignState::Cancelled) => true,
-            (CampaignState::Sucessful, CampaignState::Sucessful) => true,
+            (CampaignState::Successful, CampaignState::Successful) => true,
             (CampaignState::Progress, CampaignState::Progress) => true,
             _ => false,
         }

--- a/Introduction to Core/2. Understanding Core’s Architecture/Lesson 7 - Infrastructure of Core Blockchain.md
+++ b/Introduction to Core/2. Understanding Core’s Architecture/Lesson 7 - Infrastructure of Core Blockchain.md
@@ -73,7 +73,7 @@ Following are some of its features :
 - **Confirmation Checkup:** Ensure your transactions are secure by verifying the number of confirmations. More confirmations mean a higher level of security.
 - **Block Deep Dives:** Go beyond the surface and analyze individual blocks. Explore details like block hash, timestamps, validator information, and included transactions.
 - **Validator Watchdog:** Monitor the performance of individual validators. Track metrics like block production rate, uptime, and self-delegation to identify reliable validators.
-- **Network Pulse Check:** Gain a real-time understanding of Core blockhain's health. See live data on total transactions, active validators, circulating supply, and other essential network metrics.
+- **Network Pulse Check:** Gain a real-time understanding of Core blockchain's health. See live data on total transactions, active validators, circulating supply, and other essential network metrics.
 
 ## Core scan API
 

--- a/Launch your own token on Polygon Network in 30 mins/1. Let's Get Started/1. What Are We Building Today.md
+++ b/Launch your own token on Polygon Network in 30 mins/1. Let's Get Started/1. What Are We Building Today.md
@@ -6,7 +6,7 @@ So what are we building today? Today we will learn how to create your own Polygo
 
 Why Polygon? Polygon is a layer-2 blockchain that helps solve many issues with the Ethereum blockchain. Polygon supports EVM and Solidity, which makes it the best choice for developers like you.
 
-Not only this, Polygon commited $20 million to build web3 communities that can build on web3 and come up with scaling solutions. Polygon raised over $450,000 in 2019 in two rounds of startup, which shows how much promising the Polygon is and how much growth it will bring in web3 world.
+Not only this, Polygon committed $20 million to build web3 communities that can build on web3 and come up with scaling solutions. Polygon raised over $450,000 in 2019 in two rounds of startup, which shows how much promising the Polygon is and how much growth it will bring in web3 world.
 
 Before we start, we need to understand a few things and trust me I'm not gonna bore you!
 


### PR DESCRIPTION
- Fixed typo `Sucessful` → `Successful`
- Corrected `blockhain` → `blockchain`
- Fixed `commited` → `committed`
